### PR TITLE
Creation Model,Repo and Service Entity Comment Ticket 74)

### DIFF
--- a/src/main/java/com/alkemy/ong/entity/CommentEntity.java
+++ b/src/main/java/com/alkemy/ong/entity/CommentEntity.java
@@ -1,0 +1,47 @@
+package com.alkemy.ong.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.SQLDelete;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "COMMENTS")
+@SQLDelete(sql = "UPDATE users SET soft_delete = true WHERE id=?")
+public class CommentEntity {
+    @Id
+    @GeneratedValue(generator = "uuid")
+    @GenericGenerator(name = "uuid", strategy = "uuid2")
+    private String id;
+
+    @NotNull
+    @Column(nullable = false)
+    private String body;
+
+
+    @ManyToOne
+    @JoinColumn(name = "news",nullable = false)
+    private NewsEntity newsId;
+
+    @OneToOne
+    @JoinColumn(name = "user")
+    private UserEntity userId;
+
+    @CreationTimestamp
+    @Column(name = "TIMESTAMPS", nullable = false, updatable = false)
+    private LocalDateTime timestamps;
+
+    @Column(name = "SOFT_DELETE", nullable = false)
+    private Boolean softDelete = false;
+
+}

--- a/src/main/java/com/alkemy/ong/repository/CommentRepository.java
+++ b/src/main/java/com/alkemy/ong/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.alkemy.ong.repository;
+
+import com.alkemy.ong.entity.CommentEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<CommentEntity, String> {
+}

--- a/src/main/java/com/alkemy/ong/service/CommentService.java
+++ b/src/main/java/com/alkemy/ong/service/CommentService.java
@@ -1,0 +1,7 @@
+package com.alkemy.ong.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class CommentService {
+}


### PR DESCRIPTION
**Summary**

-Creation Entity Comment.
-Creation Repo Comment.
-Creation Service Comment.
-Add timestamp field (saving date of creation) and softDelete, not included in the ticket but necessary for the logic of future tickets.