### PR TITLE
Delete Comment only for Admin or User Creator Ticket 78

### DIFF
--- a/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
+++ b/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
@@ -88,7 +88,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers(PUT, "/news").hasAuthority("ADMIN")
                 //Comments
                 .antMatchers(POST, "/comments").hasAuthority("USER")
-
+                .antMatchers(GET, "/comments").hasAuthority("ADMIN")
                 //Slides
                 .antMatchers(GET, "/slides").hasAuthority("ADMIN")
                 .antMatchers(DELETE, "/slides/{id}").hasAuthority("ADMIN")

--- a/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
+++ b/src/main/java/com/alkemy/ong/auth/config/SecurityConfiguration.java
@@ -89,6 +89,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 //Comments
                 .antMatchers(POST, "/comments").hasAuthority("USER")
                 .antMatchers(GET, "/comments").hasAuthority("ADMIN")
+                .antMatchers(DELETE, "/comments/{id}").hasAnyAuthority("ADMIN", "USER")
                 //Slides
                 .antMatchers(GET, "/slides").hasAuthority("ADMIN")
                 .antMatchers(DELETE, "/slides/{id}").hasAuthority("ADMIN")

--- a/src/main/java/com/alkemy/ong/controller/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controller/CommentController.java
@@ -7,6 +7,7 @@ import com.alkemy.ong.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -33,4 +34,18 @@ public class CommentController {
         return ResponseEntity.ok(commentService.getAll());
     }
 
+    //Delete Comment for id only for User creator or Admin
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(Authentication aut, @PathVariable String id){
+        if(this.commentService.existId(id)){
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+        try{
+            this.commentService.delete(aut,id);
+            return new ResponseEntity<>(HttpStatus.ACCEPTED);
+        }catch (Exception e){
+            return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+        }
+
+    }
 }

--- a/src/main/java/com/alkemy/ong/controller/CommentController.java
+++ b/src/main/java/com/alkemy/ong/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.alkemy.ong.controller;
 
 
+import com.alkemy.ong.dto.CommentBodyDto;
 import com.alkemy.ong.dto.CommentDto;
 import com.alkemy.ong.service.CommentService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,7 +18,7 @@ import java.util.List;
 public class CommentController {
     @Autowired
     private  CommentService commentService;
-    //Create news entity only by User.
+    //Create news Comment only by User.
     @PostMapping()
     public ResponseEntity<CommentDto> create(@RequestBody @Valid CommentDto dto) {
         try {
@@ -26,6 +27,10 @@ public class CommentController {
             return new ResponseEntity<>(HttpStatus.UNPROCESSABLE_ENTITY);
         }
     }
-
+    //Get all Comment Body Only for ADMIN role.
+    @GetMapping()
+    public ResponseEntity<List<CommentBodyDto>> getAll(){
+        return ResponseEntity.ok(commentService.getAll());
+    }
 
 }

--- a/src/main/java/com/alkemy/ong/dto/CommentBodyDto.java
+++ b/src/main/java/com/alkemy/ong/dto/CommentBodyDto.java
@@ -1,0 +1,15 @@
+package com.alkemy.ong.dto;
+
+import lombok.*;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@ToString
+public class CommentBodyDto {
+
+    private String body;
+
+}

--- a/src/main/java/com/alkemy/ong/dto/CommentDto.java
+++ b/src/main/java/com/alkemy/ong/dto/CommentDto.java
@@ -22,5 +22,5 @@ public class CommentDto {
 
     private LocalDateTime timestamps;
 
-    private Boolean softDelete = false;
+    private Boolean softDelete;
 }

--- a/src/main/java/com/alkemy/ong/mapper/CommentMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/CommentMapper.java
@@ -1,10 +1,13 @@
 package com.alkemy.ong.mapper;
 
 
+import com.alkemy.ong.dto.CommentBodyDto;
 import com.alkemy.ong.dto.CommentDto;
 import com.alkemy.ong.entity.CommentEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
+
+import java.util.List;
 
 
 @Mapper(componentModel = "spring")
@@ -14,5 +17,8 @@ public interface CommentMapper {
     CommentDto commentEntityToCommentDto(CommentEntity comment);
 
     CommentEntity commentDtoToCommentEntity(CommentDto dto);
+
+    CommentBodyDto commentEntityToCommentBodyDto(CommentEntity comment);
+    List<CommentBodyDto> commentEntityListToCommentBodyDtoList(List<CommentEntity>comments);
 
 }

--- a/src/main/java/com/alkemy/ong/repository/CommentRepository.java
+++ b/src/main/java/com/alkemy/ong/repository/CommentRepository.java
@@ -2,8 +2,14 @@ package com.alkemy.ong.repository;
 
 import com.alkemy.ong.entity.CommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, String> {
+    //QUERY TO GET ALL COMMENTS ORDER
+    @Query(nativeQuery = true, value ="SELECT * FROM comments ORDER BY timestamps ASC")
+    List<CommentEntity> findAllByOrder();
 }

--- a/src/main/java/com/alkemy/ong/service/CommentService.java
+++ b/src/main/java/com/alkemy/ong/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.alkemy.ong.service;
 
+import com.alkemy.ong.dto.CommentBodyDto;
 import com.alkemy.ong.dto.CommentDto;
 import com.alkemy.ong.entity.CommentEntity;
 import com.alkemy.ong.mapper.CommentMapper;
@@ -8,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 
 @Service
 public class CommentService {
@@ -23,4 +25,7 @@ public class CommentService {
             return commentMapper.commentEntityToCommentDto(commentRepository.save(comment));
         }
 
+         public List<CommentBodyDto> getAll() {
+            return commentMapper.commentEntityListToCommentBodyDtoList(commentRepository.findAllByOrder());
+        }
     }

--- a/src/main/java/com/alkemy/ong/service/CommentService.java
+++ b/src/main/java/com/alkemy/ong/service/CommentService.java
@@ -6,7 +6,11 @@ import com.alkemy.ong.entity.CommentEntity;
 import com.alkemy.ong.mapper.CommentMapper;
 import com.alkemy.ong.repository.CommentRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import javax.transaction.Transactional;
 import java.util.List;
@@ -28,4 +32,40 @@ public class CommentService {
          public List<CommentBodyDto> getAll() {
             return commentMapper.commentEntityListToCommentBodyDtoList(commentRepository.findAllByOrder());
         }
+
+    @Transactional
+    public ResponseEntity<?> delete(Authentication aut, String id) {
+        if ( verifyId(aut, id)) {
+            CommentEntity entity = commentRepository.getById(id);
+            entity.setSoftDelete(true);
+            commentRepository.save(entity);
+            return new ResponseEntity<>(HttpStatus.ACCEPTED);
+        } else {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    "There is no News with the entered Id");
+        }
+    }
+
+    public boolean verifyId(Authentication aut, String id) {
+        String username = aut.getName();
+        var commentEntityOptional = commentRepository.findById(id);
+        if (commentEntityOptional.isPresent()) {
+            CommentEntity comment = commentEntityOptional.get();
+            String emailUserCreator = comment.getUserId().getEmail();
+
+            String authorityUser = aut.getAuthorities().stream().findFirst().get().toString();
+
+            if (username.equals(emailUserCreator)
+                    || authorityUser.equals("ADMIN")) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+    public boolean existId(String id) {
+       return commentRepository.findById(id).isEmpty();
+    }
     }


### PR DESCRIPTION
**Summary**

- Creation of the route to Delete Comments only for User creator or ADMIN role.
- Creation of the methods service for Delete Comment ONLY USER CREATOR and ADMIN role.
- Add path to security only accessible for User ADMIN.